### PR TITLE
Fix paged request deserialization fallback

### DIFF
--- a/src/Inventory.Web.Client/Services/WebBaseApiService.cs
+++ b/src/Inventory.Web.Client/Services/WebBaseApiService.cs
@@ -193,7 +193,8 @@ public abstract class WebBaseApiService(
     {
         try
         {
-            return await ExecuteHttpRequestAsync<PagedApiResponse<T>>(HttpMethod.Get, endpoint);
+            return await ExecuteHttpRequestAsync<PagedApiResponse<T>>(HttpMethod.Get, endpoint, null,
+                response => ErrorHandler.HandlePagedResponseAsync<T>(response));
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- update the API error handler to deserialize both wrapped and legacy paged response formats
- route paged API calls through the paged response handler so the requests list receives data

## Testing
- Not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68dfbce656cc8331a9c241d6c7fc8348