### PR TITLE
Handle numeric legacy responses when creating requests

### DIFF
--- a/src/Inventory.Web.Client/Services/ApiErrorHandler.cs
+++ b/src/Inventory.Web.Client/Services/ApiErrorHandler.cs
@@ -1,11 +1,12 @@
 using Inventory.Shared.DTOs;
 using Microsoft.Extensions.Logging;
 using System.Net;
-using System.Net.Http.Json;
 using Microsoft.AspNetCore.Components;
 using Inventory.Shared.Interfaces;
 using Radzen;
+using System.Globalization;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Inventory.Web.Client.Services;
 
@@ -35,42 +36,66 @@ public class ApiErrorHandler : IApiErrorHandler
     {
         try
         {
-            if (response.IsSuccessStatusCode)
+            if (!response.IsSuccessStatusCode)
             {
-                try
-                {
-                    var data = await response.Content.ReadFromJsonAsync<T>();
-                    _logger.LogDebug("API request successful. Status: {StatusCode}", response.StatusCode);
-
-                    if (data == null)
-                    {
-                        // Если T - это bool, и мы не можем десериализовать, предположим, что это успешная операция DELETE
-                        if (typeof(T) == typeof(bool))
-                        {
-                            return ApiResponse<T>.SuccessResult((T)(object)true);
-                        }
-                        _logger.LogWarning("Deserialized data is null for type {Type}, but a value was expected.", typeof(T).Name);
-                        return ApiResponse<T>.ErrorResult($"Failed to deserialize response for {typeof(T).Name}. Content was empty or null.");
-                    }
-                    return ApiResponse<T>.SuccessResult(data);
-                }
-                catch (System.Text.Json.JsonException jsonEx)
-                {
-                    _logger.LogWarning(jsonEx, "Failed to deserialize response as {Type}. Response content: {Content}", 
-                        typeof(T).Name, await response.Content.ReadAsStringAsync());
-                    
-                    // For DELETE operations, if we can't deserialize, assume success
-                    if (typeof(T) == typeof(bool))
-                    {
-                        _logger.LogInformation("Assuming success for boolean response that couldn't be deserialized");
-                        return ApiResponse<T>.SuccessResult((T)(object)true);
-                    }
-                    
-                    return ApiResponse<T>.ErrorResult("Failed to deserialize response data");
-                }
+                return await HandleErrorResponseAsync<T>(response);
             }
 
-            return await HandleErrorResponseAsync<T>(response);
+            var responseContent = await response.Content.ReadAsStringAsync();
+            var serializerOptions = CreateSerializerOptions();
+
+            if (string.IsNullOrWhiteSpace(responseContent))
+            {
+                if (typeof(T) == typeof(bool))
+                {
+                    _logger.LogDebug("API request successful. Status: {StatusCode}", response.StatusCode);
+                    return ApiResponse<T>.SuccessResult((T)(object)true);
+                }
+
+                _logger.LogWarning("Received empty response when expecting type {Type}", typeof(T).Name);
+                return ApiResponse<T>.ErrorResult($"Failed to deserialize response for {typeof(T).Name}. Content was empty or null.");
+            }
+
+            if (IsApiResponseWrapper(typeof(T)))
+            {
+                if (TryDeserialize(responseContent, typeof(T), serializerOptions, out var wrappedResult) && wrappedResult is T typedWrapped)
+                {
+                    if (GetSuccessValue(typedWrapped) || GetDataValue(typedWrapped) != null)
+                    {
+                        _logger.LogDebug("API request successful (wrapped format). Status: {StatusCode}", response.StatusCode);
+                        return ApiResponse<T>.SuccessResult(typedWrapped);
+                    }
+
+                    _logger.LogDebug("Wrapped response contained no data; attempting legacy fallback for type {Type}", typeof(T).Name);
+                }
+                else
+                {
+                    _logger.LogDebug("Failed to deserialize wrapped response as {Type}. Attempting legacy fallback.", typeof(T).Name);
+                }
+
+                var innerType = typeof(T).GetGenericArguments()[0];
+                if (TryDeserialize(responseContent, innerType, serializerOptions, out var legacyResult) && legacyResult != null)
+                {
+                    var adaptedResponse = CreateSuccessWrapper(innerType, legacyResult);
+                    if (adaptedResponse is T typedAdapted)
+                    {
+                        _logger.LogDebug("API request successful (legacy format). Status: {StatusCode}", response.StatusCode);
+                        return ApiResponse<T>.SuccessResult(typedAdapted);
+                    }
+                }
+
+                _logger.LogWarning("Failed to deserialize response for {Type}. Content: {Content}", typeof(T).Name, responseContent);
+                return ApiResponse<T>.ErrorResult("Failed to deserialize response data");
+            }
+
+            if (TryDeserialize(responseContent, typeof(T), serializerOptions, out var result) && result is T typedResult)
+            {
+                _logger.LogDebug("API request successful. Status: {StatusCode}", response.StatusCode);
+                return ApiResponse<T>.SuccessResult(typedResult);
+            }
+
+            _logger.LogWarning("Failed to deserialize response as {Type}. Content: {Content}", typeof(T).Name, responseContent);
+            return ApiResponse<T>.ErrorResult("Failed to deserialize response data");
         }
         catch (Exception ex)
         {
@@ -87,10 +112,7 @@ public class ApiErrorHandler : IApiErrorHandler
 
             if (response.IsSuccessStatusCode)
             {
-                var serializerOptions = new JsonSerializerOptions
-                {
-                    PropertyNameCaseInsensitive = true
-                };
+                var serializerOptions = CreateSerializerOptions();
 
                 try
                 {
@@ -336,5 +358,96 @@ public class ApiErrorHandler : IApiErrorHandler
     private ApiResponse<T> CreateAuthFailureResponse<T>()
     {
         return ApiResponse<T>.ErrorResult("Authentication required. Please log in again.");
+    }
+
+    private static JsonSerializerOptions CreateSerializerOptions()
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        options.Converters.Add(new FlexibleStringConverter());
+
+        return options;
+    }
+
+    private static bool IsApiResponseWrapper(Type type)
+    {
+        return type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ApiResponse<>);
+    }
+
+    private static bool TryDeserialize(string content, Type type, JsonSerializerOptions options, out object? result)
+    {
+        try
+        {
+            result = JsonSerializer.Deserialize(content, type, options);
+
+            if (result == null)
+            {
+                return type.IsValueType;
+            }
+
+            return true;
+        }
+        catch (JsonException)
+        {
+            result = null;
+            return false;
+        }
+    }
+
+    private static bool GetSuccessValue(object apiResponse)
+    {
+        var successProperty = apiResponse.GetType().GetProperty(nameof(ApiResponse<object>.Success));
+        return successProperty?.GetValue(apiResponse) is bool success && success;
+    }
+
+    private static object? GetDataValue(object apiResponse)
+    {
+        var dataProperty = apiResponse.GetType().GetProperty(nameof(ApiResponse<object>.Data));
+        return dataProperty?.GetValue(apiResponse);
+    }
+
+    private static object? CreateSuccessWrapper(Type innerType, object data)
+    {
+        var wrapperType = typeof(ApiResponse<>).MakeGenericType(innerType);
+        var instance = Activator.CreateInstance(wrapperType);
+
+        if (instance == null)
+        {
+            return null;
+        }
+
+        var successProperty = wrapperType.GetProperty(nameof(ApiResponse<object>.Success));
+        var dataProperty = wrapperType.GetProperty(nameof(ApiResponse<object>.Data));
+
+        successProperty?.SetValue(instance, true);
+        dataProperty?.SetValue(instance, data);
+
+        return instance;
+    }
+
+    private sealed class FlexibleStringConverter : JsonConverter<string>
+    {
+        public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return reader.TokenType switch
+            {
+                JsonTokenType.String => reader.GetString(),
+                JsonTokenType.Number => reader.TryGetInt64(out var longValue)
+                    ? longValue.ToString(CultureInfo.InvariantCulture)
+                    : reader.GetDouble().ToString(CultureInfo.InvariantCulture),
+                JsonTokenType.True => bool.TrueString,
+                JsonTokenType.False => bool.FalseString,
+                JsonTokenType.Null => null,
+                _ => reader.GetRawText()
+            };
+        }
+
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value);
+        }
     }
 }

--- a/src/Inventory.Web.Client/Services/WebRequestApiService.cs
+++ b/src/Inventory.Web.Client/Services/WebRequestApiService.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using Inventory.Shared.Constants;
 using Inventory.Shared.DTOs;
 using Inventory.Shared.Interfaces;
@@ -52,6 +53,7 @@ public class WebRequestApiService : WebBaseApiService, IRequestApiService
         {
             var endpoint = ApiEndpoints.RequestById.Replace("{id}", requestId.ToString());
             Logger.LogDebug("Getting request by ID: {RequestId}", requestId);
+
             return await GetAsync<RequestDetailsDto>(endpoint);
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- add a flexible string converter to the API error handler so legacy payloads that emit numeric statuses can be deserialized
- centralize JSON serializer configuration so both standard and paged handlers benefit from the converter

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfc334f0d4833181db538e3a876822