### PR TITLE
Add request line item capture to procurement flows

### DIFF
--- a/src/Inventory.API/Services/RequestService.cs
+++ b/src/Inventory.API/Services/RequestService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Inventory.API.Models;
 using Inventory.Shared.Interfaces;
@@ -9,7 +10,8 @@ namespace Inventory.API.Services;
 
 public interface IRequestService
 {
-    Task<Request> CreateRequestAsync(string title, string createdByUserId, string? description = null, CancellationToken ct = default);
+    Task<Request> CreateRequestAsync(CreateRequestDto createRequest, string createdByUserId, CancellationToken ct = default);
+    Task<Request> UpdateRequestAsync(int requestId, UpdateRequestDto updateRequest, string userId, CancellationToken ct = default);
     Task<Inventory.API.Models.InventoryTransaction> AddPendingItemAsync(int requestId, int productId, int warehouseId, int quantity, string userId, int? locationId = null, decimal? unitPrice = null, string? description = null, CancellationToken ct = default);
 
     Task<Request> SubmitAsync(int requestId, string userId, string? comment = null, CancellationToken ct = default);
@@ -23,26 +25,157 @@ public interface IRequestService
 
 public class RequestService(AppDbContext db, INotificationService notificationService, ILogger<RequestService> logger) : IRequestService
 {
-    public async Task<Request> CreateRequestAsync(string title, string createdByUserId, string? description = null, CancellationToken ct = default)
+    public async Task<Request> CreateRequestAsync(CreateRequestDto createRequest, string createdByUserId, CancellationToken ct = default)
     {
+        ArgumentNullException.ThrowIfNull(createRequest);
+
+        if (string.IsNullOrWhiteSpace(createRequest.Title))
+        {
+            throw new ArgumentException("Request title is required", nameof(createRequest.Title));
+        }
+
+        if (createRequest.Items == null || createRequest.Items.Count == 0)
+        {
+            throw new ArgumentException("At least one item must be provided when creating a request", nameof(createRequest.Items));
+        }
+
+        await using var transaction = await db.Database.BeginTransactionAsync(ct);
+
         var request = new Request
         {
-            Title = title,
-            Description = description,
+            Title = createRequest.Title.Trim(),
+            Description = string.IsNullOrWhiteSpace(createRequest.Description) ? null : createRequest.Description.Trim(),
             Status = RequestStatus.Draft,
             CreatedByUserId = createdByUserId,
             CreatedAt = DateTime.UtcNow
         };
+
         db.Requests.Add(request);
         await db.SaveChangesAsync(ct);
+
+        foreach (var item in createRequest.Items)
+        {
+            await AddPendingItemInternalAsync(
+                request.Id,
+                item.ProductId,
+                item.WarehouseId,
+                item.Quantity,
+                createdByUserId,
+                item.LocationId,
+                item.UnitPrice,
+                item.Description,
+                ct);
+        }
+
         await AddHistoryAsync(request, null, RequestStatus.Draft, createdByUserId, "Request created", ct);
+
+        await transaction.CommitAsync(ct);
+
+        return request;
+    }
+
+    public async Task<Request> UpdateRequestAsync(int requestId, UpdateRequestDto updateRequest, string userId, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(updateRequest);
+
+        if (string.IsNullOrWhiteSpace(updateRequest.Title))
+        {
+            throw new ArgumentException("Request title is required", nameof(updateRequest.Title));
+        }
+
+        if (updateRequest.Items == null || updateRequest.Items.Count == 0)
+        {
+            throw new ArgumentException("At least one item must be provided when updating a request", nameof(updateRequest.Items));
+        }
+
+        var request = await db.Requests
+            .Include(r => r.Transactions.Where(t => t.Type == TransactionType.Pending))
+            .FirstOrDefaultAsync(r => r.Id == requestId, ct)
+            ?? throw new InvalidOperationException("Request not found");
+
+        EnsureStatus(request, [RequestStatus.Draft]);
+
+        await using var transaction = await db.Database.BeginTransactionAsync(ct);
+
+        request.Title = updateRequest.Title.Trim();
+        request.Description = string.IsNullOrWhiteSpace(updateRequest.Description) ? null : updateRequest.Description.Trim();
+        request.UpdatedAt = DateTime.UtcNow;
+        await db.SaveChangesAsync(ct);
+
+        var existingPending = await db.InventoryTransactions
+            .Where(t => t.RequestId == requestId && t.Type == TransactionType.Pending)
+            .ToListAsync(ct);
+
+        if (existingPending.Count > 0)
+        {
+            db.InventoryTransactions.RemoveRange(existingPending);
+            await db.SaveChangesAsync(ct);
+        }
+
+        foreach (var item in updateRequest.Items)
+        {
+            await AddPendingItemInternalAsync(
+                requestId,
+                item.ProductId,
+                item.WarehouseId,
+                item.Quantity,
+                userId,
+                item.LocationId,
+                item.UnitPrice,
+                item.Description,
+                ct);
+        }
+
+        await transaction.CommitAsync(ct);
+
         return request;
     }
 
     public async Task<Inventory.API.Models.InventoryTransaction> AddPendingItemAsync(int requestId, int productId, int warehouseId, int quantity, string userId, int? locationId = null, decimal? unitPrice = null, string? description = null, CancellationToken ct = default)
     {
+        return await AddPendingItemInternalAsync(requestId, productId, warehouseId, quantity, userId, locationId, unitPrice, description, ct);
+    }
+
+    private async Task<Inventory.API.Models.InventoryTransaction> AddPendingItemInternalAsync(
+        int requestId,
+        int productId,
+        int warehouseId,
+        int quantity,
+        string userId,
+        int? locationId,
+        decimal? unitPrice,
+        string? description,
+        CancellationToken ct)
+    {
+        if (quantity <= 0)
+        {
+            throw new ArgumentException("Quantity must be greater than zero", nameof(quantity));
+        }
+
         var request = await db.Requests.FirstOrDefaultAsync(r => r.Id == requestId, ct) ?? throw new InvalidOperationException("Request not found");
         EnsureStatus(request, [RequestStatus.Draft, RequestStatus.Submitted, RequestStatus.Approved, RequestStatus.InProgress]);
+
+        // Ensure related entities exist
+        var productExists = await db.Products.AnyAsync(p => p.Id == productId, ct);
+        if (!productExists)
+        {
+            throw new ArgumentException($"Product with id {productId} not found", nameof(productId));
+        }
+
+        var warehouseExists = await db.Warehouses.AnyAsync(w => w.Id == warehouseId, ct);
+        if (!warehouseExists)
+        {
+            throw new ArgumentException($"Warehouse with id {warehouseId} not found", nameof(warehouseId));
+        }
+
+        if (locationId.HasValue)
+        {
+            var locationExists = await db.Locations.AnyAsync(l => l.Id == locationId.Value, ct);
+            if (!locationExists)
+            {
+                throw new ArgumentException($"Location with id {locationId.Value} not found", nameof(locationId));
+            }
+        }
 
         var trx = new Inventory.API.Models.InventoryTransaction
         {

--- a/src/Inventory.Shared/DTOs/RequestDtos.cs
+++ b/src/Inventory.Shared/DTOs/RequestDtos.cs
@@ -18,6 +18,7 @@ public class RequestDetailsDto
     public DateTime CreatedAt { get; set; }
     public DateTime? UpdatedAt { get; set; }
     public string CreatedByUserId { get; set; } = string.Empty;
+    public List<RequestItemDetailsDto> Items { get; set; } = new();
     public List<TransactionRow> Transactions { get; set; } = new();
     public List<HistoryRow> History { get; set; } = new();
 }

--- a/src/Inventory.Shared/DTOs/RequestItemDtos.cs
+++ b/src/Inventory.Shared/DTOs/RequestItemDtos.cs
@@ -1,0 +1,17 @@
+namespace Inventory.Shared.DTOs;
+
+public class RequestItemDetailsDto
+{
+    public int Id { get; set; }
+    public int ProductId { get; set; }
+    public string ProductName { get; set; } = string.Empty;
+    public string? ProductSku { get; set; }
+    public int WarehouseId { get; set; }
+    public string WarehouseName { get; set; } = string.Empty;
+    public int Quantity { get; set; }
+    public int? LocationId { get; set; }
+    public string? LocationName { get; set; }
+    public decimal? UnitPrice { get; set; }
+    public decimal? TotalPrice { get; set; }
+    public string? Description { get; set; }
+}

--- a/src/Inventory.Shared/Interfaces/IRequestApiService.cs
+++ b/src/Inventory.Shared/Interfaces/IRequestApiService.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using Inventory.Shared.DTOs;
 
 namespace Inventory.Shared.Interfaces;
@@ -24,7 +26,7 @@ public interface IRequestApiService
     Task<ApiResponse<RequestDetailsDto>> RejectRequestAsync(int requestId, string? comment = null);
     
     // Request item management
-    Task<ApiResponse<TransactionRow>> AddRequestItemAsync(int requestId, AddRequestItemDto addItemRequest);
+    Task<ApiResponse<RequestDetailsDto>> AddRequestItemAsync(int requestId, AddRequestItemDto addItemRequest);
     Task<ApiResponse<bool>> RemoveRequestItemAsync(int requestId, int itemId);
 }
 
@@ -33,8 +35,15 @@ public interface IRequestApiService
 /// </summary>
 public class CreateRequestDto
 {
+    [Required]
+    [StringLength(200, MinimumLength = 3)]
     public string Title { get; set; } = string.Empty;
+
+    [StringLength(1000)]
     public string? Description { get; set; }
+
+    [MinLength(1, ErrorMessage = "At least one request item must be provided")]
+    public ICollection<RequestItemInputDto> Items { get; set; } = new List<RequestItemInputDto>();
 }
 
 /// <summary>
@@ -42,19 +51,43 @@ public class CreateRequestDto
 /// </summary>
 public class UpdateRequestDto
 {
+    [Required]
+    [StringLength(200, MinimumLength = 3)]
     public string Title { get; set; } = string.Empty;
+
+    [StringLength(1000)]
+    public string? Description { get; set; }
+
+    [MinLength(1, ErrorMessage = "At least one request item must be provided")]
+    public ICollection<RequestItemInputDto> Items { get; set; } = new List<RequestItemInputDto>();
+}
+
+/// <summary>
+/// DTO describing an item included in a request when creating or updating it
+/// </summary>
+public class RequestItemInputDto
+{
+    [Required]
+    public int ProductId { get; set; }
+
+    [Required]
+    public int WarehouseId { get; set; }
+
+    [Range(1, int.MaxValue, ErrorMessage = "Quantity must be greater than zero")]
+    public int Quantity { get; set; }
+
+    public int? LocationId { get; set; }
+
+    [Range(0, double.MaxValue, ErrorMessage = "Unit price must be zero or positive")]
+    public decimal? UnitPrice { get; set; }
+
+    [StringLength(500)]
     public string? Description { get; set; }
 }
 
 /// <summary>
 /// DTO for adding an item to a request
 /// </summary>
-public class AddRequestItemDto
+public class AddRequestItemDto : RequestItemInputDto
 {
-    public int ProductId { get; set; }
-    public int WarehouseId { get; set; }
-    public int Quantity { get; set; }
-    public int? LocationId { get; set; }
-    public decimal? UnitPrice { get; set; }
-    public string? Description { get; set; }
 }

--- a/src/Inventory.Web.Client/Pages/Requests/Create.razor
+++ b/src/Inventory.Web.Client/Pages/Requests/Create.razor
@@ -4,12 +4,15 @@
 @using Inventory.Shared.DTOs
 @using Inventory.Shared.Interfaces
 @using System.ComponentModel.DataAnnotations
+@using System.Linq
 @using Radzen
 @using Radzen.Blazor
 
 @inject IRequestApiService RequestService
 @inject NavigationManager Navigation
 @inject NotificationService NotificationService
+@inject IProductService ProductService
+@inject IWarehouseService WarehouseService
 
 @attribute [Authorize]
 
@@ -28,7 +31,7 @@
         @* Form *@
         <EditForm Model="@createRequest" OnValidSubmit="@HandleSubmit">
             <DataAnnotationsValidator />
-            
+
             <RadzenStack Gap="1.5rem">
                 @* Basic Information *@
                 <RadzenCard Class="rz-p-4">
@@ -69,9 +72,137 @@
                     </RadzenStack>
                 </RadzenCard>
 
+                @* Request Items *@
+                <RadzenCard Class="rz-p-4">
+                    <RadzenStack Gap="1rem">
+                        <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" JustifyContent="JustifyContent.SpaceBetween">
+                            <RadzenText TextStyle="TextStyle.H6" Class="rz-m-0">Request Items</RadzenText>
+                            <RadzenButton Text="Add Item"
+                                          Icon="add"
+                                          ButtonStyle="ButtonStyle.Secondary"
+                                          Click="AddItem"
+                                          Disabled="submitting || isLoadingLookups" />
+                        </RadzenStack>
+
+                        @if (isLoadingLookups)
+                        {
+                            <RadzenStack Orientation="Orientation.Horizontal" Gap="0.5rem" AlignItems="AlignItems.Center">
+                                <RadzenProgressBarCircular ShowValue="false" Mode="ProgressBarMode.Indeterminate" Size="ProgressBarCircularSize.Small" />
+                                <RadzenText TextStyle="TextStyle.Body2">Loading products and warehouses...</RadzenText>
+                            </RadzenStack>
+                        }
+
+                        @if (createRequest.Items.Count == 0)
+                        {
+                            <RadzenAlert AlertStyle="AlertStyle.Info" Shade="Shade.Lighter" Variant="Variant.Flat">
+                                <RadzenText TextStyle="TextStyle.Body2">Add at least one item to this request.</RadzenText>
+                            </RadzenAlert>
+                        }
+                        else
+                        {
+                            <RadzenStack Gap="1rem">
+                                @for (var index = 0; index < createRequest.Items.Count; index++)
+                                {
+                                    var item = createRequest.Items[index];
+                                    <RadzenCard Class="rz-p-3">
+                                        <RadzenStack Gap="1rem">
+                                            <RadzenRow Gap="1rem">
+                                                <RadzenColumn Size="12" SizeMd="6">
+                                                    <RadzenStack Gap="0.5rem">
+                                                        <RadzenLabel Text="Product *" Component=$"product-{index}" />
+                                                        <RadzenDropDown Data="products"
+                                                                        TextProperty="Name"
+                                                                        ValueProperty="Id"
+                                                                        AllowFiltering="true"
+                                                                        FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
+                                                                        @bind-Value="item.ProductId"
+                                                                        Name=$"product-{index}"
+                                                                        Placeholder="Select product"
+                                                                        Style="width: 100%"
+                                                                        Disabled="isLoadingLookups || submitting" />
+                                                        <ValidationMessage For="@(() => createRequest.Items[index].ProductId)" />
+                                                    </RadzenStack>
+                                                </RadzenColumn>
+                                                <RadzenColumn Size="12" SizeMd="6">
+                                                    <RadzenStack Gap="0.5rem">
+                                                        <RadzenLabel Text="Warehouse *" Component=$"warehouse-{index}" />
+                                                        <RadzenDropDown Data="warehouses"
+                                                                        TextProperty="Name"
+                                                                        ValueProperty="Id"
+                                                                        AllowFiltering="true"
+                                                                        FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
+                                                                        @bind-Value="item.WarehouseId"
+                                                                        Name=$"warehouse-{index}"
+                                                                        Placeholder="Select warehouse"
+                                                                        Style="width: 100%"
+                                                                        Disabled="isLoadingLookups || submitting" />
+                                                        <ValidationMessage For="@(() => createRequest.Items[index].WarehouseId)" />
+                                                    </RadzenStack>
+                                                </RadzenColumn>
+                                            </RadzenRow>
+
+                                            <RadzenRow Gap="1rem">
+                                                <RadzenColumn Size="12" SizeMd="4">
+                                                    <RadzenStack Gap="0.5rem">
+                                                        <RadzenLabel Text="Quantity *" Component=$"quantity-{index}" />
+                                                        <RadzenNumeric Style="width: 100%"
+                                                                       Name=$"quantity-{index}"
+                                                                       @bind-Value="item.Quantity"
+                                                                       Min="1"
+                                                                       ShowUpDown="true"
+                                                                       Step="1"
+                                                                       Disabled="submitting" />
+                                                        <ValidationMessage For="@(() => createRequest.Items[index].Quantity)" />
+                                                    </RadzenStack>
+                                                </RadzenColumn>
+
+                                                <RadzenColumn Size="12" SizeMd="4">
+                                                    <RadzenStack Gap="0.5rem">
+                                                        <RadzenLabel Text="Unit Price" Component=$"price-{index}" />
+                                                        <RadzenNumeric @bind-Value="item.UnitPrice"
+                                                                       Name=$"price-{index}"
+                                                                       Style="width: 100%"
+                                                                       Min="0"
+                                                                       Step="0.01"
+                                                                       Disabled="submitting" />
+                                                    </RadzenStack>
+                                                </RadzenColumn>
+                                            </RadzenRow>
+
+                                            <RadzenRow Gap="1rem">
+                                                <RadzenColumn Size="12">
+                                                    <RadzenStack Gap="0.5rem">
+                                                        <RadzenLabel Text="Description" Component=$"description-{index}" />
+                                                        <RadzenTextArea @bind-Value="item.Description"
+                                                                        Name=$"description-{index}"
+                                                                        Placeholder="Additional notes for this item"
+                                                                        Style="width: 100%"
+                                                                        Rows="2"
+                                                                        MaxLength="500"
+                                                                        Disabled="submitting" />
+                                                    </RadzenStack>
+                                                </RadzenColumn>
+                                            </RadzenRow>
+
+                                            <RadzenStack Orientation="Orientation.Horizontal" JustifyContent="JustifyContent.End">
+                                                <RadzenButton Text="Remove"
+                                                              Icon="delete"
+                                                              ButtonStyle="ButtonStyle.Danger"
+                                                              Size="ButtonSize.Small"
+                                                              Click="@(() => RemoveItem(item))"
+                                                              Disabled="submitting" />
+                                            </RadzenStack>
+                                        </RadzenStack>
+                                    </RadzenCard>
+                                }
+                            </RadzenStack>
+                        }
+                    </RadzenStack>
+                </RadzenCard>
+
                 @* Actions *@
                 <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" Gap="1rem">
-                    <RadzenButton Text="Create Request" 
+                    <RadzenButton Text="Create Request"
                                   Icon="add_circle" 
                                   ButtonStyle="ButtonStyle.Primary"
                                   ButtonType="ButtonType.Submit"
@@ -122,6 +253,18 @@
 @code {
     private CreateRequestModel createRequest = new();
     private bool submitting = false;
+    private bool isLoadingLookups = false;
+    private List<ProductDto> products = new();
+    private List<WarehouseDto> warehouses = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadLookupsAsync();
+        if (createRequest.Items.Count == 0)
+        {
+            createRequest.Items.Add(new RequestItemModel());
+        }
+    }
 
     private async Task HandleSubmit()
     {
@@ -132,10 +275,23 @@
 
         try
         {
+            if (createRequest.Items.Count == 0)
+            {
+                NotificationService.Notify(new Radzen.NotificationMessage
+                {
+                    Severity = NotificationSeverity.Warning,
+                    Summary = "Missing items",
+                    Detail = "Add at least one item to the request before submitting.",
+                    Duration = 4000
+                });
+                return;
+            }
+
             var dto = new CreateRequestDto
             {
                 Title = createRequest.Title?.Trim() ?? string.Empty,
-                Description = string.IsNullOrWhiteSpace(createRequest.Description) ? null : createRequest.Description.Trim()
+                Description = string.IsNullOrWhiteSpace(createRequest.Description) ? null : createRequest.Description.Trim(),
+                Items = createRequest.Items.Select(item => item.ToInputDto()).ToList()
             };
 
             var response = await RequestService.CreateRequestAsync(dto);
@@ -181,6 +337,43 @@
         }
     }
 
+    private async Task LoadLookupsAsync()
+    {
+        try
+        {
+            isLoadingLookups = true;
+            products = await ProductService.GetAllProductsAsync();
+            warehouses = await WarehouseService.GetAllWarehousesAsync();
+        }
+        catch (Exception ex)
+        {
+            NotificationService.Notify(new Radzen.NotificationMessage
+            {
+                Severity = NotificationSeverity.Error,
+                Summary = "Lookup Load Failed",
+                Detail = $"Failed to load products or warehouses: {ex.Message}",
+                Duration = 5000
+            });
+        }
+        finally
+        {
+            isLoadingLookups = false;
+            StateHasChanged();
+        }
+    }
+
+    private void AddItem()
+    {
+        createRequest.Items.Add(new RequestItemModel());
+        StateHasChanged();
+    }
+
+    private void RemoveItem(RequestItemModel item)
+    {
+        createRequest.Items.Remove(item);
+        StateHasChanged();
+    }
+
     public class CreateRequestModel
     {
         [Required(ErrorMessage = "Title is required")]
@@ -190,5 +383,40 @@
 
         [StringLength(1000, ErrorMessage = "Description cannot exceed 1000 characters")]
         public string? Description { get; set; }
+
+        [MinLength(1, ErrorMessage = "At least one request item is required")]
+        public List<RequestItemModel> Items { get; set; } = new();
+    }
+
+    public class RequestItemModel
+    {
+        [Required(ErrorMessage = "Product is required")]
+        public int? ProductId { get; set; }
+
+        [Required(ErrorMessage = "Warehouse is required")]
+        public int? WarehouseId { get; set; }
+
+        [Range(1, int.MaxValue, ErrorMessage = "Quantity must be at least 1")]
+        public int Quantity { get; set; } = 1;
+
+        [Range(0, double.MaxValue, ErrorMessage = "Unit price cannot be negative")]
+        public decimal? UnitPrice { get; set; }
+
+        public string? Description { get; set; }
+
+        public int? LocationId { get; set; }
+
+        public RequestItemInputDto ToInputDto()
+        {
+            return new RequestItemInputDto
+            {
+                ProductId = ProductId ?? 0,
+                WarehouseId = WarehouseId ?? 0,
+                Quantity = Quantity,
+                UnitPrice = UnitPrice,
+                Description = string.IsNullOrWhiteSpace(Description) ? null : Description.Trim(),
+                LocationId = LocationId
+            };
+        }
     }
 }

--- a/src/Inventory.Web.Client/Pages/Requests/Details.razor
+++ b/src/Inventory.Web.Client/Pages/Requests/Details.razor
@@ -157,43 +157,44 @@
             }
 
             @* Request Items *@
+            <RadzenCard Class="rz-p-4">
+                <RadzenStack Gap="1rem">
+                    <RadzenText TextStyle="TextStyle.H6" Class="rz-m-0">Request Items</RadzenText>
+
+                    @if (request.Items?.Count > 0)
+                    {
+                        <RadzenDataGrid Data="@request.Items" TItem="RequestItemDetailsDto" AllowPaging="true" PageSize="10">
+                            <Columns>
+                                <RadzenDataGridColumn TItem="RequestItemDetailsDto" Property="ProductName" Title="Product" />
+                                <RadzenDataGridColumn TItem="RequestItemDetailsDto" Property="ProductSku" Title="SKU" Width="120px" />
+                                <RadzenDataGridColumn TItem="RequestItemDetailsDto" Property="WarehouseName" Title="Warehouse" />
+                                <RadzenDataGridColumn TItem="RequestItemDetailsDto" Property="Quantity" Title="Quantity" Width="100px" />
+                                <RadzenDataGridColumn TItem="RequestItemDetailsDto" Property="UnitPrice" Title="Unit Price" FormatString="{0:C}" Width="120px" />
+                                <RadzenDataGridColumn TItem="RequestItemDetailsDto" Property="TotalPrice" Title="Total" FormatString="{0:C}" Width="120px" />
+                                <RadzenDataGridColumn TItem="RequestItemDetailsDto" Property="Description" Title="Description" />
+                            </Columns>
+                        </RadzenDataGrid>
+                    }
+                    else
+                    {
+                        <RadzenAlert AlertStyle="AlertStyle.Info" Shade="Shade.Lighter" Variant="Variant.Flat">
+                            <RadzenText TextStyle="TextStyle.Body2">No items have been added to this request yet.</RadzenText>
+                        </RadzenAlert>
+                    }
+                </RadzenStack>
+            </RadzenCard>
+
             @if (request.Transactions?.Count > 0)
             {
                 <RadzenCard Class="rz-p-4">
                     <RadzenStack Gap="1rem">
-                        <RadzenText TextStyle="TextStyle.H6" Class="rz-m-0">Request Items</RadzenText>
+                        <RadzenText TextStyle="TextStyle.H6" Class="rz-m-0">Transaction History</RadzenText>
                         <RadzenDataGrid Data="@request.Transactions" TItem="TransactionRow" AllowPaging="true" PageSize="10">
                             <Columns>
-                                <RadzenDataGridColumn TItem="TransactionRow" Property="Type" Title="Type" Width="100px" />
+                                <RadzenDataGridColumn TItem="TransactionRow" Property="Type" Title="Type" Width="120px" />
                                 <RadzenDataGridColumn TItem="TransactionRow" Property="Quantity" Title="Quantity" Width="100px" />
-                                <RadzenDataGridColumn TItem="TransactionRow" Property="Date" Title="Date" FormatString="{0:MMM dd, yyyy}" Width="120px" />
+                                <RadzenDataGridColumn TItem="TransactionRow" Property="Date" Title="Date" FormatString="{0:MMM dd, yyyy}" Width="140px" />
                                 <RadzenDataGridColumn TItem="TransactionRow" Property="Description" Title="Description" />
-                                <RadzenDataGridColumn TItem="TransactionRow" Title="Product" Width="100px">
-                                    <Template Context="transaction">
-                                        @if (transaction.ProductId.HasValue)
-                                        {
-                                            <RadzenButton Text="View" Icon="visibility" ButtonStyle="ButtonStyle.Light" Size="ButtonSize.Small"
-                                                          Click="@(() => Navigation.NavigateTo($"/products/{transaction.ProductId}"))" />
-                                        }
-                                        else
-                                        {
-                                            <RadzenText TextStyle="TextStyle.Body2" Class="rz-text-secondary">N/A</RadzenText>
-                                        }
-                                    </Template>
-                                </RadzenDataGridColumn>
-                                <RadzenDataGridColumn TItem="TransactionRow" Title="Warehouse" Width="100px">
-                                    <Template Context="transaction">
-                                        @if (transaction.WarehouseId.HasValue)
-                                        {
-                                            <RadzenButton Text="View" Icon="visibility" ButtonStyle="ButtonStyle.Light" Size="ButtonSize.Small"
-                                                          Click="@(() => Navigation.NavigateTo($"/warehouses/{transaction.WarehouseId}"))" />
-                                        }
-                                        else
-                                        {
-                                            <RadzenText TextStyle="TextStyle.Body2" Class="rz-text-secondary">N/A</RadzenText>
-                                        }
-                                    </Template>
-                                </RadzenDataGridColumn>
                             </Columns>
                         </RadzenDataGrid>
                     </RadzenStack>

--- a/src/Inventory.Web.Client/Pages/Requests/Edit.razor
+++ b/src/Inventory.Web.Client/Pages/Requests/Edit.razor
@@ -5,12 +5,16 @@
 @using Inventory.Shared.Interfaces
 @using Inventory.Web.Client.Components.Shared
 @using System.ComponentModel.DataAnnotations
+@using System
+@using System.Linq
 @using Radzen
 @using Radzen.Blazor
 
 @inject IRequestApiService RequestService
 @inject NavigationManager Navigation
 @inject NotificationService NotificationService
+@inject IProductService ProductService
+@inject IWarehouseService WarehouseService
 
 @attribute [Authorize]
 
@@ -77,7 +81,7 @@
             @* Form *@
             <EditForm Model="@editRequest" OnValidSubmit="@HandleSubmit">
                 <DataAnnotationsValidator />
-                
+
                 <RadzenStack Gap="1.5rem">
                     @* Basic Information *@
                     <RadzenCard Class="rz-p-4">
@@ -118,6 +122,134 @@
                         </RadzenStack>
                     </RadzenCard>
 
+                    @* Request Items *@
+                    <RadzenCard Class="rz-p-4">
+                        <RadzenStack Gap="1rem">
+                            <RadzenStack Orientation="Orientation.Horizontal" AlignItems="AlignItems.Center" JustifyContent="JustifyContent.SpaceBetween">
+                                <RadzenText TextStyle="TextStyle.H6" Class="rz-m-0">Request Items</RadzenText>
+                                <RadzenButton Text="Add Item"
+                                              Icon="add"
+                                              ButtonStyle="ButtonStyle.Secondary"
+                                              Click="AddItem"
+                                              Disabled="submitting || isLoadingLookups" />
+                            </RadzenStack>
+
+                            @if (isLoadingLookups)
+                            {
+                                <RadzenStack Orientation="Orientation.Horizontal" Gap="0.5rem" AlignItems="AlignItems.Center">
+                                    <RadzenProgressBarCircular ShowValue="false" Mode="ProgressBarMode.Indeterminate" Size="ProgressBarCircularSize.Small" />
+                                    <RadzenText TextStyle="TextStyle.Body2">Loading products and warehouses...</RadzenText>
+                                </RadzenStack>
+                            }
+
+                            @if (editRequest.Items.Count == 0)
+                            {
+                                <RadzenAlert AlertStyle="AlertStyle.Warning" Shade="Shade.Lighter" Variant="Variant.Flat">
+                                    <RadzenText TextStyle="TextStyle.Body2">Add at least one item before saving changes.</RadzenText>
+                                </RadzenAlert>
+                            }
+                            else
+                            {
+                                <RadzenStack Gap="1rem">
+                                    @for (var index = 0; index < editRequest.Items.Count; index++)
+                                    {
+                                        var item = editRequest.Items[index];
+                                        <RadzenCard Class="rz-p-3">
+                                            <RadzenStack Gap="1rem">
+                                                <RadzenRow Gap="1rem">
+                                                    <RadzenColumn Size="12" SizeMd="6">
+                                                        <RadzenStack Gap="0.5rem">
+                                                            <RadzenLabel Text="Product *" Component=$"product-{index}" />
+                                                            <RadzenDropDown Data="products"
+                                                                            TextProperty="Name"
+                                                                            ValueProperty="Id"
+                                                                            AllowFiltering="true"
+                                                                            FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
+                                                                            @bind-Value="item.ProductId"
+                                                                            Name=$"product-{index}"
+                                                                            Placeholder="Select product"
+                                                                            Style="width: 100%"
+                                                                            Disabled="isLoadingLookups || submitting" />
+                                                            <ValidationMessage For="@(() => editRequest.Items[index].ProductId)" />
+                                                        </RadzenStack>
+                                                    </RadzenColumn>
+                                                    <RadzenColumn Size="12" SizeMd="6">
+                                                        <RadzenStack Gap="0.5rem">
+                                                            <RadzenLabel Text="Warehouse *" Component=$"warehouse-{index}" />
+                                                            <RadzenDropDown Data="warehouses"
+                                                                            TextProperty="Name"
+                                                                            ValueProperty="Id"
+                                                                            AllowFiltering="true"
+                                                                            FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
+                                                                            @bind-Value="item.WarehouseId"
+                                                                            Name=$"warehouse-{index}"
+                                                                            Placeholder="Select warehouse"
+                                                                            Style="width: 100%"
+                                                                            Disabled="isLoadingLookups || submitting" />
+                                                            <ValidationMessage For="@(() => editRequest.Items[index].WarehouseId)" />
+                                                        </RadzenStack>
+                                                    </RadzenColumn>
+                                                </RadzenRow>
+
+                                                <RadzenRow Gap="1rem">
+                                                    <RadzenColumn Size="12" SizeMd="4">
+                                                        <RadzenStack Gap="0.5rem">
+                                                            <RadzenLabel Text="Quantity *" Component=$"quantity-{index}" />
+                                                            <RadzenNumeric Style="width: 100%"
+                                                                           Name=$"quantity-{index}"
+                                                                           @bind-Value="item.Quantity"
+                                                                           Min="1"
+                                                                           ShowUpDown="true"
+                                                                           Step="1"
+                                                                           Disabled="submitting" />
+                                                            <ValidationMessage For="@(() => editRequest.Items[index].Quantity)" />
+                                                        </RadzenStack>
+                                                    </RadzenColumn>
+
+                                                    <RadzenColumn Size="12" SizeMd="4">
+                                                        <RadzenStack Gap="0.5rem">
+                                                            <RadzenLabel Text="Unit Price" Component=$"price-{index}" />
+                                                            <RadzenNumeric @bind-Value="item.UnitPrice"
+                                                                           Name=$"price-{index}"
+                                                                           Style="width: 100%"
+                                                                           Min="0"
+                                                                           Step="0.01"
+                                                                           Disabled="submitting" />
+                                                        </RadzenStack>
+                                                    </RadzenColumn>
+                                                </RadzenRow>
+
+                                                <RadzenRow Gap="1rem">
+                                                    <RadzenColumn Size="12">
+                                                        <RadzenStack Gap="0.5rem">
+                                                            <RadzenLabel Text="Description" Component=$"description-{index}" />
+                                                            <RadzenTextArea @bind-Value="item.Description"
+                                                                            Name=$"description-{index}"
+                                                                            Placeholder="Additional notes for this item"
+                                                                            Style="width: 100%"
+                                                                            Rows="2"
+                                                                            MaxLength="500"
+                                                                            Disabled="submitting" />
+                                                        </RadzenStack>
+                                                    </RadzenColumn>
+                                                </RadzenRow>
+
+                                                <RadzenStack Orientation="Orientation.Horizontal" JustifyContent="JustifyContent.End">
+                                                    <RadzenButton Text="Remove"
+                                                                  Icon="delete"
+                                                                  ButtonStyle="ButtonStyle.Danger"
+                                                                  Size="ButtonSize.Small"
+                                                                  Click="@(() => RemoveItem(item))"
+                                                                  Disabled="submitting" />
+                                                </RadzenStack>
+                                            </RadzenStack>
+                                        </RadzenCard>
+                                    }
+                                </RadzenStack>
+                            }
+                        </RadzenStack>
+                    </RadzenCard>
+
                     @* Change Summary *@
                     @if (HasChanges())
                     {
@@ -132,6 +264,10 @@
                                     @if (editRequest.Description != originalRequest.Description)
                                     {
                                         <RadzenText TextStyle="TextStyle.Body2" Class="rz-m-0">• Description has been modified</RadzenText>
+                                    }
+                                    @if (!ItemsMatchOriginal())
+                                    {
+                                        <RadzenText TextStyle="TextStyle.Body2" Class="rz-m-0">• Request items have been modified</RadzenText>
                                     }
                                 </RadzenStack>
                             </RadzenStack>
@@ -203,9 +339,15 @@
     private bool loading = true;
     private bool submitting = false;
     private string? errorMessage;
+    private bool isLoadingLookups = false;
+    private List<ProductDto> products = new();
+    private List<WarehouseDto> warehouses = new();
+    private List<RequestItemModel> originalItemsSnapshot = new();
+    private bool lookupsLoaded;
 
     protected override async Task OnInitializedAsync()
     {
+        await LoadLookupsAsync();
         await LoadRequestDetails();
     }
 
@@ -213,6 +355,7 @@
     {
         if (originalRequest?.Id != Id)
         {
+            await LoadLookupsAsync();
             await LoadRequestDetails();
         }
     }
@@ -230,13 +373,29 @@
             if (response.Success && response.Data != null)
             {
                 originalRequest = response.Data;
-                
+
                 // Initialize edit model with current values
                 editRequest = new EditRequestModel
                 {
                     Title = originalRequest.Title,
-                    Description = originalRequest.Description
+                    Description = originalRequest.Description,
+                    Items = originalRequest.Items.Select(item => new RequestItemModel
+                    {
+                        ProductId = item.ProductId,
+                        WarehouseId = item.WarehouseId,
+                        Quantity = item.Quantity,
+                        UnitPrice = item.UnitPrice,
+                        Description = item.Description,
+                        LocationId = item.LocationId
+                    }).ToList()
                 };
+
+                if (editRequest.Items.Count == 0)
+                {
+                    editRequest.Items.Add(new RequestItemModel());
+                }
+
+                originalItemsSnapshot = editRequest.Items.Select(item => item.Clone()).ToList();
             }
             else
             {
@@ -265,10 +424,23 @@
 
         try
         {
+            if (editRequest.Items.Count == 0)
+            {
+                NotificationService.Notify(new Radzen.NotificationMessage
+                {
+                    Severity = NotificationSeverity.Warning,
+                    Summary = "Missing items",
+                    Detail = "Add at least one item to the request before saving.",
+                    Duration = 4000
+                });
+                return;
+            }
+
             var dto = new UpdateRequestDto
             {
                 Title = editRequest.Title?.Trim() ?? string.Empty,
-                Description = string.IsNullOrWhiteSpace(editRequest.Description) ? null : editRequest.Description.Trim()
+                Description = string.IsNullOrWhiteSpace(editRequest.Description) ? null : editRequest.Description.Trim(),
+                Items = editRequest.Items.Select(item => item.ToInputDto()).ToList()
             };
 
             var response = await RequestService.UpdateRequestAsync(originalRequest.Id, dto);
@@ -314,6 +486,49 @@
         }
     }
 
+    private async Task LoadLookupsAsync()
+    {
+        if (lookupsLoaded)
+        {
+            return;
+        }
+
+        try
+        {
+            isLoadingLookups = true;
+            products = await ProductService.GetAllProductsAsync();
+            warehouses = await WarehouseService.GetAllWarehousesAsync();
+        }
+        catch (Exception ex)
+        {
+            NotificationService.Notify(new Radzen.NotificationMessage
+            {
+                Severity = NotificationSeverity.Error,
+                Summary = "Lookup Load Failed",
+                Detail = $"Failed to load products or warehouses: {ex.Message}",
+                Duration = 5000
+            });
+        }
+        finally
+        {
+            isLoadingLookups = false;
+            lookupsLoaded = true;
+            StateHasChanged();
+        }
+    }
+
+    private void AddItem()
+    {
+        editRequest.Items.Add(new RequestItemModel());
+        StateHasChanged();
+    }
+
+    private void RemoveItem(RequestItemModel item)
+    {
+        editRequest.Items.Remove(item);
+        StateHasChanged();
+    }
+
     private bool CanEdit()
     {
         return originalRequest?.Status?.Equals("Draft", StringComparison.OrdinalIgnoreCase) == true;
@@ -322,9 +537,28 @@
     private bool HasChanges()
     {
         if (originalRequest == null) return false;
-        
+
         return editRequest.Title != originalRequest.Title ||
-               editRequest.Description != originalRequest.Description;
+               editRequest.Description != originalRequest.Description ||
+               !ItemsMatchOriginal();
+    }
+
+    private bool ItemsMatchOriginal()
+    {
+        if (originalItemsSnapshot.Count != editRequest.Items.Count)
+        {
+            return false;
+        }
+
+        for (var i = 0; i < editRequest.Items.Count; i++)
+        {
+            if (!editRequest.Items[i].Equals(originalItemsSnapshot[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public class EditRequestModel
@@ -336,5 +570,73 @@
 
         [StringLength(1000, ErrorMessage = "Description cannot exceed 1000 characters")]
         public string? Description { get; set; }
+
+        [MinLength(1, ErrorMessage = "At least one request item is required")]
+        public List<RequestItemModel> Items { get; set; } = new();
+    }
+
+    public class RequestItemModel
+    {
+        [Required(ErrorMessage = "Product is required")]
+        public int? ProductId { get; set; }
+
+        [Required(ErrorMessage = "Warehouse is required")]
+        public int? WarehouseId { get; set; }
+
+        [Range(1, int.MaxValue, ErrorMessage = "Quantity must be at least 1")]
+        public int Quantity { get; set; } = 1;
+
+        [Range(0, double.MaxValue, ErrorMessage = "Unit price cannot be negative")]
+        public decimal? UnitPrice { get; set; }
+
+        public string? Description { get; set; }
+
+        public int? LocationId { get; set; }
+
+        public RequestItemInputDto ToInputDto()
+        {
+            return new RequestItemInputDto
+            {
+                ProductId = ProductId ?? 0,
+                WarehouseId = WarehouseId ?? 0,
+                Quantity = Quantity,
+                UnitPrice = UnitPrice,
+                Description = string.IsNullOrWhiteSpace(Description) ? null : Description.Trim(),
+                LocationId = LocationId
+            };
+        }
+
+        public RequestItemModel Clone()
+        {
+            return new RequestItemModel
+            {
+                ProductId = ProductId,
+                WarehouseId = WarehouseId,
+                Quantity = Quantity,
+                UnitPrice = UnitPrice,
+                Description = Description,
+                LocationId = LocationId
+            };
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (obj is not RequestItemModel other)
+            {
+                return false;
+            }
+
+            return ProductId == other.ProductId &&
+                   WarehouseId == other.WarehouseId &&
+                   Quantity == other.Quantity &&
+                   Nullable.Equals(UnitPrice, other.UnitPrice) &&
+                   string.Equals(Description, other.Description, StringComparison.Ordinal) &&
+                   LocationId == other.LocationId;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(ProductId, WarehouseId, Quantity, UnitPrice, Description, LocationId);
+        }
     }
 }

--- a/src/Inventory.Web.Client/Services/WebRequestApiService.cs
+++ b/src/Inventory.Web.Client/Services/WebRequestApiService.cs
@@ -216,17 +216,17 @@ public class WebRequestApiService : WebBaseApiService, IRequestApiService
 
     #region Request Item Management
 
-    public async Task<ApiResponse<TransactionRow>> AddRequestItemAsync(int requestId, AddRequestItemDto addItemRequest)
+    public async Task<ApiResponse<RequestDetailsDto>> AddRequestItemAsync(int requestId, AddRequestItemDto addItemRequest)
     {
         try
         {
             var endpoint = ApiEndpoints.RequestItems.Replace("{id}", requestId.ToString());
             Logger.LogDebug("Adding item to request: {RequestId}, ProductId: {ProductId}", requestId, addItemRequest.ProductId);
-            return await PostAsync<TransactionRow>(endpoint, addItemRequest);
+            return await PostAsync<RequestDetailsDto>(endpoint, addItemRequest);
         }
         catch (Exception ex)
         {
-            return await ErrorHandler.HandleExceptionAsync<TransactionRow>(ex, $"AddRequestItem - {requestId}");
+            return await ErrorHandler.HandleExceptionAsync<RequestDetailsDto>(ex, $"AddRequestItem - {requestId}");
         }
     }
 


### PR DESCRIPTION
## Summary
- extend request DTOs and API endpoints to accept item details during create, update, and item additions
- enrich request details with product and warehouse metadata and expose the data to the client
- update Blazor create/edit/detail pages to manage request items and validate inputs on the client
- refresh unit and integration tests to exercise the new request item workflow

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e365dc93388331a1a68eee916ab698